### PR TITLE
feat: rebrand to Auth HI!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ web-ext-artifacts/
 # Notes (discussion, research, planning)
 notes/
 
+*.zip

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auth-header-injector",
   "version": "0.1.0",
-  "description": "Chrome extension for injecting auth headers into requests. Built with SDK Kit.",
+  "description": "Auth HI! - Chrome extension for injecting auth headers. Built with SDK Kit.",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Auth Header Injector",
+  "name": "Auth HI!",
   "version": "0.1.0",
-  "description": "Inject authentication headers into HTTP requests based on URL patterns",
+  "description": "Say hi to hassle-free auth headers. Inject authentication headers into requests based on URL patterns.",
   "icons": {
     "16": "icon-16.png",
     "48": "icon-48.png",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,12 +19,5 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
-    rollupOptions: {
-      output: {
-        // Use relative paths for assets
-        assetFileNames: '[name].[ext]',
-      },
-    },
   },
-  base: './', // Use relative paths
 });


### PR DESCRIPTION
Rebrands the extension to Auth HI! with updated manifest and build configuration.

Changes:
- Update manifest name to "Auth HI!" with tagline "Say hi to hassle-free auth headers"
- Update package.json description with Auth HI! branding
- Add postcss.config.cjs for proper Tailwind CSS processing (fixes styling issues)
- Fix vite.config.ts for correct asset path resolution in Chrome extension
- Add *.zip to .gitignore for build artifacts

Ready for Chrome Web Store submission with:
- New branding throughout the extension
- Working CSS/styling in production builds
- Clean build artifacts excluded from repo

The extension is now built and ready for Chrome Web Store listing as Auth HI!